### PR TITLE
Update to Makie v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OSMMakie"
 uuid = "76b6901f-8821-46bb-9129-841bc9cfe677"
 repo = "https://github.com/MakieOrg/OSMMakie.jl"
 authors = ["Frederik Banning <frederik.banning@ruhr-uni-bochum.de>"]
-version = "0.0.5"
+version = "0.0.6-DEV"
 
 [deps]
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
@@ -11,8 +11,8 @@ LightOSM = "d1922b25-af4e-4ba3-84af-fe9bea896051"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
-julia = "1.6, 1.7"
-GraphMakie = "0.3"
+julia = "1.6"
+GraphMakie = "0.4"
 Graphs = "1.5"
 LightOSM = "0.2"
-Makie = "0.16, 0.17"
+Makie = "0.18"

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -15,9 +15,6 @@ function Makie.show_data(inspector::DataInspector,
     node = osm.nodes[osm.index_to_node[idx]]
     a.text[] = node2string(node)
     ms = source.markersize[][idx]
-#    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
-#    a._px_bbox_visible[] = true
-#    a._bbox_visible[] = false
     a.visible[] = true
     a.range = 1
     a.textsize = 13
@@ -70,9 +67,6 @@ function Makie.show_data(inspector::DataInspector,
     way = plot.index_to_way[][idx÷2]
 
     a.text[] = edge2string(way)
-#    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* lw .- Vec2f(5), Vec2f(lw) .+ Vec2f(10))
-#    a._px_bbox_visible[] = true
-#    a._bbox_visible[] = false
     a.visible[] = true
     a.range = 1
     a.textsize = 13

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -13,12 +13,12 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
 
     node = osm.nodes[osm.index_to_node[idx]]
-    a._display_text[] = node2string(node)
+    a.text[] = node2string(node)
     ms = source.markersize[][idx]
-    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
-    a._px_bbox_visible[] = true
-    a._bbox_visible[] = false
-    a._visible[] = true
+#    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
+#    a._px_bbox_visible[] = true
+#    a._bbox_visible[] = false
+    a.visible[] = true
     a.range = 1
     a.textsize = 13
 
@@ -69,11 +69,11 @@ function Makie.show_data(inspector::DataInspector,
     # With plot.index_to_way:
     way = plot.index_to_way[][idx÷2]
 
-    a._display_text[] = edge2string(way)
-    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* lw .- Vec2f(5), Vec2f(lw) .+ Vec2f(10))
-    a._px_bbox_visible[] = true
-    a._bbox_visible[] = false
-    a._visible[] = true
+    a.text[] = edge2string(way)
+#    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* lw .- Vec2f(5), Vec2f(lw) .+ Vec2f(10))
+#    a._px_bbox_visible[] = true
+#    a._bbox_visible[] = false
+    a.visible[] = true
     a.range = 1
     a.textsize = 13
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ buildings = buildings_from_file(london_buildings);
     if get(ENV, "CI", nothing) == "true"
         @test_throws ArgumentError osmplot(; osm)
     else
-        @test_throws MethodError osmplot(; osm)
+        @test_throws Makie.PlotMethodError osmplot(; osm)
     end
 
     @test begin # recipe with buildings and limits/autolimitaspect keywords

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,12 +32,8 @@ buildings = buildings_from_file(london_buildings);
         true
     end
 
-    # wrong recipe usage, for whatever reasons this is different between CI and local
-    if get(ENV, "CI", nothing) == "true"
-        @test_throws ArgumentError osmplot(; osm)
-    else
-        @test_throws Makie.PlotMethodError osmplot(; osm)
-    end
+    # wrong recipe usage
+    @test_throws Makie.PlotMethodError osmplot(; osm)
 
     @test begin # recipe with buildings and limits/autolimitaspect keywords
         fig = Figure()


### PR DESCRIPTION
Tests pass locally. I had to change https://github.com/MakieOrg/OSMMakie.jl/blob/v0.0.5/test/runtests.jl#L48 to `Makie.PlotMethodError`.  Let's see what CI says.  Otherwise I would have kept compatibility with Makie = "0.16, 0.17" and Graphs "0.3".

Note that compat `julia = "1.6"` includes 1.7 and 1.8, so no need to explicitly state those.